### PR TITLE
Run derby on 7251. Run spliceengine on 1527.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.log
 node_modules
 mydb.*
+.idea/
+test/testdb/

--- a/bin/startdbs
+++ b/bin/startdbs
@@ -1,5 +1,4 @@
 #!/bin/bash
 java -cp drivers\/hsqldb.jar org.hsqldb.server.Server --database.0 file:test\/mydb --dbname.0 xdb >test\/hsqldb.log 2>&1 &
-java -Dderby.system.home=./test -classpath drivers\/derby.jar:drivers\/derbynet.jar:drivers\/derbytools.jar -jar drivers\/derbyrun.jar server start >test\/derby.log 2>&1 &
-sleep 10
-/Users/admin/Downloads/splicemachine/bin/start-splice-1528.sh
+java -Dderby.drda.portNumber=7251 -Dderby.system.home=./test -classpath drivers\/derby.jar:drivers\/derbynet.jar:drivers\/derbytools.jar -jar drivers\/derbyrun.jar server start >test\/derby.log 2>&1 &
+sleep 5

--- a/bin/stopdbs
+++ b/bin/stopdbs
@@ -3,5 +3,3 @@ java -jar drivers/sqltool.jar --rcfile test\/sqltool.rc --sql "SHUTDOWN;" xdb
 java -classpath drivers/derby.jar:drivers/derbytools.jar:drivers/derbynet.jar -jar drivers/derbyrun.jar server shutdown
 rm -rf test/testdb
 rm -rf test/mydb.*
-/Users/admin/Downloads/splicemachine/bin/stop-splice.sh
-/Users/admin/Downloads/splicemachine/bin/clean.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jdbc",
-  "version": "0.6.0",
+  "version": "0.6.2-pre.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -38,9 +38,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
         "lodash": "4.17.4"
       }
@@ -626,7 +626,6 @@
       "resolved": "https://registry.npmjs.org/java/-/java-0.9.0.tgz",
       "integrity": "sha1-1J2iw6rV4stYmpaKgKM0/nMIoP4=",
       "requires": {
-        "async": "2.5.0",
         "find-java-home": "0.2.0",
         "glob": "7.1.2",
         "lodash": "4.17.4",
@@ -738,9 +737,9 @@
       "dev": true
     },
     "lolex": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.1.2.tgz",
-      "integrity": "sha1-JpS5U8nqTQE+W4v7qJHJkQJbJik=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
+      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==",
       "dev": true
     },
     "lru-cache": {
@@ -2521,9 +2520,9 @@
       "dev": true
     },
     "q": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
     "qs": {
@@ -2943,9 +2942,9 @@
       "integrity": "sha1-ugZWKbepJRMOFXeRCM9UCZDpjRs="
     },
     "winston": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
-      "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
       "requires": {
         "async": "1.0.0",
         "colors": "1.0.3",

--- a/test/test-derby.js
+++ b/test/test-derby.js
@@ -12,7 +12,7 @@ if (!jinst.isJvmCreated()) {
 }
 
 var derby = new JDBC({
-  url: 'jdbc:derby://localhost:1527/testdb;create=true'
+  url: 'jdbc:derby://localhost:7251/testdb;create=true'
 });
 
 var testconn = null;

--- a/test/test-multi.js
+++ b/test/test-multi.js
@@ -16,7 +16,7 @@ var configWithUserInUrl = {
 };
 
 var configderby = {
-  url: 'jdbc:derby://localhost:1527/testdb'
+  url: 'jdbc:derby://localhost:7251/testdb'
 };
 
 var hsqldb = new JDBC(configWithUserInUrl);

--- a/test/test-splice-connection.js
+++ b/test/test-splice-connection.js
@@ -14,7 +14,7 @@ if (!jinst.isJvmCreated()) {
                         './drivers/derbytools.jar']);
 }
 var config = {
-    url: 'jdbc:splice://localhost:1528/splicedb;user=splice;password=admin',
+    url: 'jdbc:splice://localhost:1527/splicedb;user=splice;password=admin',
   user : 'user',
   password: 'admin'
 };

--- a/test/test-splice.js
+++ b/test/test-splice.js
@@ -12,7 +12,7 @@ if (!jinst.isJvmCreated()) {
 }
 
 var splice = new JDBC({
-  url: 'jdbc:splice://localhost:1528/splicedb;user=splice;password=admin'
+  url: 'jdbc:splice://localhost:1527/splicedb;user=splice;password=admin'
 });
 
 var testconn = null;

--- a/test/test-statement-adjust.js
+++ b/test/test-statement-adjust.js
@@ -12,7 +12,7 @@ if (!jinst.isJvmCreated()) {
 }
 
 var derby = new JDBC({
-  url: 'jdbc:derby://localhost:1527/testdb;create=true'
+  url: 'jdbc:derby://localhost:7251/testdb;create=true'
 });
 
 var testconn = null;

--- a/test/test-txn.js
+++ b/test/test-txn.js
@@ -12,7 +12,7 @@ if (!jinst.isJvmCreated()) {
 }
 
 var config = {
-  url: 'jdbc:derby://localhost:1527/testdb;create=true',
+  url: 'jdbc:derby://localhost:7251/testdb;create=true',
 };
 
 var derby = new JDBC(config);


### PR DESCRIPTION
I saw that the Derby driver was able to run on a different port. This article outlined that:
https://db.apache.org/derby/docs/10.5/adminguide/tadminappssettingportnumbers.html

I think that running it on a different port eliminates the concerns with it colliding with the ports spliceengine wants to use locally. So I changed all references to derby to point to the configured port.

The npm script `posttest` still won't run because `test` fails with nonzero. I think that's fine. I'm sure if we could get the tests (or subset) working, it would clean up its test database.

Monte, I've asked for your review because I wanted to know if you went down this path and it didn't work as well as running spliceengine on a different port. I would rather bend dependencies to my will than our codebase ;) I'm going forward with this path, so not time sensitive.